### PR TITLE
Making possible to set extra sip headers to call action

### DIFF
--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -263,7 +263,7 @@ void Action::do_accept(vector<ActionParam> &params) {
 	acc->code = code;
 }
 
-void Action::do_call(vector<ActionParam> &params) {
+void Action::do_call(vector<ActionParam> &params, SipHeaderVector &x_headers) {
 	string type {"call"};
 	string play {default_playback_file};
 	string play_dtmf {};
@@ -377,6 +377,11 @@ void Action::do_call(vector<ActionParam> &params) {
 		test->type = type;
 		acc->calls.push_back(call);
 		CallOpParam prm(true);
+
+		for (auto x_hdr : x_headers) {
+			prm.txOption.headers.push_back(x_hdr);
+		}
+
 		prm.opt.audioCount = 1;
 		prm.opt.videoCount = 0;
 		LOG(logINFO) << "call->test:" << test << " " << call->test->type;

--- a/src/voip_patrol/action.hh
+++ b/src/voip_patrol/action.hh
@@ -22,6 +22,7 @@
 #include "voip_patrol.hh"
 #include <iostream>
 #include <vector>
+#include <pjsua2.hpp>
 
 class Config;
 
@@ -47,7 +48,7 @@ class Action {
 			vector<ActionParam> get_params(string);
 			bool set_param(ActionParam&, const char *val);
 			bool set_param_by_name(vector<ActionParam> *params, const string name, const char *val=nullptr);
-			void do_call(vector<ActionParam> &params);
+			void do_call(vector<ActionParam> &params, pj::SipHeaderVector &x_headers);
 			void do_accept(vector<ActionParam> &params);
 			void do_wait(vector<ActionParam> &params);
 			void do_register(vector<ActionParam> &params);

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -635,7 +635,7 @@ TestAccount* Config::findAccount(std::string account_name) {
 }
 
 bool Config::process(std::string p_configFileName, std::string p_jsonResultFileName) {
-	ezxml_t xml_actions, xml_action;
+	ezxml_t xml_actions, xml_action, xml_xhdr;
 	configFileName = p_configFileName;
 	ezxml_t xml_conf = ezxml_parse_file(configFileName.c_str());
 	xml_conf_head = xml_conf; // saving the head if the linked list
@@ -664,7 +664,16 @@ bool Config::process(std::string p_configFileName, std::string p_jsonResultFileN
 				action.set_param(param, ezxml_attr(xml_action, param.name.c_str()));
 			}
 			if ( action_type.compare("wait") == 0 ) action.do_wait(params);
-			else if ( action_type.compare("call") == 0 ) action.do_call(params);
+			else if ( action_type.compare("call") == 0 ) {
+				SipHeaderVector x_hdrs = SipHeaderVector();
+				for (xml_xhdr = ezxml_child(xml_action, "x-header"); xml_xhdr; xml_xhdr=xml_xhdr->next) {
+					SipHeader sh = SipHeader();
+					sh.hName = ezxml_attr(xml_xhdr, "name");
+					sh.hValue = ezxml_attr(xml_xhdr, "value");
+					x_hdrs.push_back(sh);
+				}
+				action.do_call(params, x_hdrs);
+			}
 			else if ( action_type.compare("accept") == 0 ) action.do_accept(params);
 			else if ( action_type.compare("register") == 0 ) action.do_register(params);
 			else if ( action_type.compare("alert") == 0 ) action.do_alert(params);


### PR DESCRIPTION
Fix #2 

```xml
<config>
  <actions>
    <action type="call" label="us-east-va"
            transport="udp"
            expected_cause_code="200"
            caller="15147371787@noreply.com"
            callee="12344656@target.com"
            max_duration="20" hangup="20"
            rtp_stats
            >
      <x-header name="X-Foo" value="Bar" />
    </action>
    <!-- note: param value starting with VP_ENV_ will
               be replaced by environment variables -->
    <!-- note: rtp_stats will include RTP transmission
               statistics -->
    <action type="wait" complete/>
  </actions>
</config>
```

```
INVITE sip:12344656@target.com SIP/2.0
Via: SIP/2.0/UDP 172.16.7.137:5061;rport;branch=z9hG4bKPjY3oVhqiEtHLGl.SyktVzPvw9FdkOfqY2
Max-Forwards: 70
From: sip:15147371787@noreply.com;tag=FT6AALTJwXUX7ZcZfUvPyLvxkG4vWnP7
To: sip:12344656@target.com
Contact: <sip:15147371787@172.16.7.137:5061;ob>
Call-ID: aMc.kWt1aL1mNxW1uW5S0m.7O2hHcJNs
CSeq: 23088 INVITE
Allow: PRACK, INVITE, ACK, BYE, CANCEL, UPDATE, INFO, SUBSCRIBE, NOTIFY, REFER, MESSAGE, OPTIONS
Supported: replaces, 100rel, timer, norefersub
Session-Expires: 1800
Min-SE: 90
X-Foo: Bar
Content-Type: application/sdp
Content-Length:   531
```