### PR TITLE
add transfer action type

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,51 @@ config>
 </config>
 ```
 
+### Example: making a test call and blind transferring
+```xml
+<config>
+  <actions>
+    <action type="call" label="us-east-va"
+            transport="tls"
+            expected_cause_code="200"
+            caller="15147371787@noreply.com"
+            callee="12012665228@target.com"
+            to_uri="+12012665228@target.com"
+            max_duration="20" hangup="16"
+            username="VP_ENV_USERNAME"
+            password="VP_ENV_PASSWORD"
+            realm="target.com"
+            rtp_stats
+    >
+        <x-header name="X-Foo" value="Bar"/>
+    </action>
+    <!-- note: blind_transfer (and attended_transfer) inherit variables from initial call -->
+    <action type="transfer" transfer_type="blind" to_uri="12012665228@target.com"/>
+  </actions>
+</config>
+```
+
+### Example: receiving a test call and attended transferring
+```xml
+<config>
+  <actions>
+     <!-- note: default is the "catch all" account,
+          else account as to match called number -->
+    <action type="accept"
+            account="default"
+            hangup="5"
+            play_dtmf="0123456789#*"
+            play="voice_ref_files/f.wav"
+            code="200" reason="YES"
+            ring_duration="5"
+    />
+    <!-- note: attended_transfer (and blind_transfer) inherit variables from initial call -->
+               forever and generate test results -->
+    <action type="transfer" transfer_type="attended" to_uri="12012665228@target.com"/>
+  </actions>
+</config>
+```
+
 ### accept command parameters (partial list)
 
 | Name | Type | Description | 

--- a/README.md
+++ b/README.md
@@ -235,49 +235,62 @@ config>
 </config>
 ```
 
-### Example: making a test call and blind transferring
+### Example: making a call and blind transferring
+
 ```xml
 <config>
   <actions>
-    <action type="call" label="us-east-va"
-            transport="tls"
-            expected_cause_code="200"
-            caller="15147371787@noreply.com"
-            callee="12012665228@target.com"
-            to_uri="+12012665228@target.com"
-            max_duration="20" hangup="16"
-            username="VP_ENV_USERNAME"
-            password="VP_ENV_PASSWORD"
-            realm="target.com"
-            rtp_stats
-    >
-        <x-header name="X-Foo" value="Bar"/>
-    </action>
-    <!-- note: blind_transfer (and attended_transfer) inherit variables from initial call -->
-    <action type="transfer" transfer_type="blind" to_uri="12012665228@target.com"/>
+    <action type="accept" label="CALLEE recieves call and blind transfer"
+      account="VP_ENV_CALLEE_USERNAME"
+      wait_until="DISCONNECTED"
+      play="../voice_ref_files/reference_8000.wav"
+      code="200" reason="OK"
+      ring_duration="5"
+      rtp_stats
+    />
+
+    <!-- note: call ends once transfer is complete -->
+    <action type="transfer" blind to_uri="VPN_ENV_TRANSFER_TARGET@VPN_ENV_PROXY"/>
+  </action>
+</config>
+```
+
+### Example: receiving a call and attended transferring
+
+```xml
+<config>
+  <actions>
+    <!-- note: default is the "catch all" account,
+      else account as to match called number -->
+    <action type="accept" label="CALLEE recieves call and blind transfer"
+      account="VP_ENV_CALLEE_USERNAME"
+      wait_until="DISCONNECTED"
+      play="../voice_ref_files/reference_8000.wav"
+      code="200" reason="OK"
+      ring_duration="5"
+      rtp_stats
+    />
+    <!-- note: attended_transfer inherit variables from initial call -->
+    <action type="transfer" attended to_uri="12012665228@target.com"/>
   </actions>
 </config>
 ```
 
-### Example: receiving a test call and attended transferring
-```xml
-<config>
-  <actions>
-     <!-- note: default is the "catch all" account,
-          else account as to match called number -->
-    <action type="accept"
-            account="default"
-            hangup="5"
-            play_dtmf="0123456789#*"
-            play="voice_ref_files/f.wav"
-            code="200" reason="YES"
-            ring_duration="5"
-    />
-    <!-- note: attended_transfer (and blind_transfer) inherit variables from initial call -->
-               forever and generate test results -->
-    <action type="transfer" transfer_type="attended" to_uri="12012665228@target.com"/>
-  </actions>
-</config>
+### Set up environment variables from file
+
+`voip_patrol.env`:
+
+```bash
+VP_ENV_DOMAIN=sip.example.com
+VP_ENV_PROXY=192.168.0.1:5060
+VP_ENV_CALLEE_EXTENSION=1000
+VP_ENV_CALLEE_USERNAME=1000
+VP_ENV_CALLEE_PASSWORD=password
+VP_ENV_TRANSFER_TARGET=15557776666
+```
+
+```bash
+export $(xargs <voip_patrol.env)
 ```
 
 ### accept command parameters (partial list)

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ config>
 </config>
 ```
 
-### Example: making a call and blind transferring
+### Example: receive a call and transferring
 
 ```xml
 <config>
   <actions>
-    <action type="accept" label="CALLEE recieves call and blind transfer"
+    <action type="accept" label="receive_and_transfer"
       account="VP_ENV_CALLEE_USERNAME"
       wait_until="DISCONNECTED"
       play="../voice_ref_files/reference_8000.wav"
@@ -248,49 +248,28 @@ config>
       ring_duration="5"
       rtp_stats
     />
-
     <!-- note: call ends once transfer is complete -->
-    <action type="transfer" blind to_uri="VPN_ENV_TRANSFER_TARGET@VPN_ENV_PROXY"/>
+    <action type="transfer" to_uri="12015555555@target.com"/>
   </action>
 </config>
 ```
 
-### Example: receiving a call and attended transferring
+### Example: send a call and transferring
 
 ```xml
 <config>
   <actions>
-    <!-- note: default is the "catch all" account,
-      else account as to match called number -->
-    <action type="accept" label="CALLEE recieves call and blind transfer"
-      account="VP_ENV_CALLEE_USERNAME"
-      wait_until="DISCONNECTED"
-      play="../voice_ref_files/reference_8000.wav"
-      code="200" reason="OK"
-      ring_duration="5"
-      rtp_stats
+    <action type="call" label="make_and_transfer"
+            transport="udp"
+            wait_until="CONFIRMED"
+            expected_cause_code="200"
+            caller="15147777777@noreply.com"
+            callee="12012222222@target.com"
     />
-    <!-- note: attended_transfer inherit variables from initial call -->
-    <action type="transfer" attended to_uri="12012665228@target.com"/>
+    <!-- note: call ends once transfer is complete -->
+    <action type="transfer" to_uri="12015555555@target.com"/>
   </actions>
 </config>
-```
-
-### Set up environment variables from file
-
-`voip_patrol.env`:
-
-```bash
-VP_ENV_DOMAIN=sip.example.com
-VP_ENV_PROXY=192.168.0.1:5060
-VP_ENV_CALLEE_EXTENSION=1000
-VP_ENV_CALLEE_USERNAME=1000
-VP_ENV_CALLEE_PASSWORD=password
-VP_ENV_TRANSFER_TARGET=15557776666
-```
-
-```bash
-export $(xargs <voip_patrol.env)
 ```
 
 ### accept command parameters (partial list)
@@ -332,6 +311,23 @@ Example : `username="VP_ENV_USERNAME"`
 ```bash
 export VP_ENV_PASSWORD=????????
 export VP_ENV_USERNAME=username
+```
+
+### Set up environment variables from file
+
+`voip_patrol.env`:
+
+```bash
+VP_ENV_DOMAIN=sip.example.com
+VP_ENV_PROXY=192.168.0.1:5060
+VP_ENV_CALLEE_EXTENSION=1000
+VP_ENV_CALLEE_USERNAME=1000
+VP_ENV_CALLEE_PASSWORD=password
+VP_ENV_TRANSFER_TARGET=15557776666
+```
+
+```bash
+export $(xargs <voip_patrol.env)
 ```
 
 ### Docker

--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -698,7 +698,6 @@ void Action::do_transfer(vector<ActionParam> &params) {
 								call->setHold(prm); // put the current call on hold
 								call->makeCall("<sip:" + to_uri + ">", prm, "<sip:" + to_uri + ">");
 								call->xferReplaces("<sip:" + to_uri + ">", prm);
-								LOG(logERROR) <<__FUNCTION__<<": incorrect action parameter. attended type not implemented" ;
 								return;
 							} else if (blind) {
 								LOG(logINFO) <<__FUNCTION__<<": doing blind transfer" ;

--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -125,8 +125,6 @@ void Action::init_actions_params() {
 	do_alert_params.push_back(ActionParam("email_from", false, APType::apt_string));
 	do_alert_params.push_back(ActionParam("smtp_host", false, APType::apt_string));
 	// do_transfer
-	do_transfer_params.push_back(ActionParam("blind", false, APType::apt_bool));
-	do_transfer_params.push_back(ActionParam("attended", false, APType::apt_bool));
 	do_transfer_params.push_back(ActionParam("to_uri", false, APType::apt_string));
 }
 
@@ -624,21 +622,12 @@ void Action::do_transfer(vector<ActionParam> &params) {
 	bool status_update = true;
 	bool complete_all = false;
 
-	bool blind {false};
-	bool attended {false};
 	string to_uri {};
 
 	bool transferring = false;
 
 	for (auto param : params) {
-		if (param.name.compare("blind") == 0) blind = param.b_val;
-		if (param.name.compare("attended") == 0) attended = param.b_val;
 		if (param.name.compare("to_uri") == 0) to_uri = param.s_val;
-	}
-
-	if (!blind && !attended ) {
-		LOG(logERROR) <<__FUNCTION__<<": missing action parameters for transfer type or blind or attended" ;
-		return;
 	}
 
 	if (to_uri.empty() ) {
@@ -692,21 +681,9 @@ void Action::do_transfer(vector<ActionParam> &params) {
 
 						if (!transferring) {
 							// check transfer_type
-							if (attended) {
-								LOG(logINFO) <<__FUNCTION__<<": doing attended transfer" ;
-								transferring = true;
-								call->setHold(prm); // put the current call on hold
-								call->makeCall("<sip:" + to_uri + ">", prm, "<sip:" + to_uri + ">");
-								call->xferReplaces("<sip:" + to_uri + ">", prm);
-								return;
-							} else if (blind) {
-								LOG(logINFO) <<__FUNCTION__<<": doing blind transfer" ;
-								transferring = true;
-								call->xfer("<sip:" + to_uri + ">", prm);
-							} else {
-								LOG(logERROR) <<__FUNCTION__<<": incorrect action parameter. Pass either blind or attended" ;
-								return;
-							}
+							LOG(logINFO) <<__FUNCTION__<<": doing transfer" ;
+							transferring = true;
+							call->xfer("<sip:" + to_uri + ">", prm);
 						}
 						
 					} catch (pj::Error e)  {

--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -670,9 +670,7 @@ void Action::do_transfer(vector<ActionParam> &params) {
 						}
 					}
 				} else if (ci.state == PJSIP_INV_STATE_CONFIRMED) {
-					std::string res = "call[" + std::to_string(ci.lastStatusCode) + "] reason["+ ci.lastReason +"]";
 					CallOpParam prm(true);
-					LOG(logINFO) <<__FUNCTION__<<": call in PJSIP_INV_STATE_CONFIRMED" ;
 					try {
 						if (to_uri.empty() ) {
 							LOG(logERROR) <<__FUNCTION__<<": missing action parameters for to_uri" ;

--- a/src/voip_patrol/action.hh
+++ b/src/voip_patrol/action.hh
@@ -51,6 +51,7 @@ class Action {
 			void do_wait(vector<ActionParam> &params);
 			void do_register(vector<ActionParam> &params, pj::SipHeaderVector &x_headers);
 			void do_alert(vector<ActionParam> &params);
+			void do_transfer(vector<ActionParam> &params);
 			void set_config(Config *);
 			Config* get_config();
 	private:
@@ -61,6 +62,7 @@ class Action {
 			vector<ActionParam> do_wait_params;
 			vector<ActionParam> do_accept_params;
 			vector<ActionParam> do_alert_params;
+			vector<ActionParam> do_transfer_params;
 			Config* config;
 };
 

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -337,6 +337,10 @@ void TestCall::onCallState(OnCallStateParam &prm) {
 	}
 }
 
+void TestCall::onCallTransferStatus(OnCallTransferStatusParam &prm) {
+
+}
+
 
 /*
  * TestAccount implementation
@@ -790,6 +794,7 @@ bool Config::process(std::string p_configFileName, std::string p_jsonResultFileN
 			else if ( action_type.compare("accept") == 0 ) action.do_accept(params, x_hdrs);
 			else if ( action_type.compare("register") == 0 ) action.do_register(params, x_hdrs);
 			else if ( action_type.compare("alert") == 0 ) action.do_alert(params);
+			else if ( action_type.compare("transfer") == 0 ) action.do_transfer(params);
 		}
 	}
 }

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -338,7 +338,25 @@ void TestCall::onCallState(OnCallStateParam &prm) {
 }
 
 void TestCall::onCallTransferStatus(OnCallTransferStatusParam &prm) {
+	PJ_UNUSED_ARG(prm);
+	CallInfo ci = getInfo();
 
+	LOG(logINFO) <<__FUNCTION__<<": ["<<getId()<<"]["<<ci.remoteUri<<"]["<<ci.stateText<<"]id["<<ci.callIdString<<"]";
+	LOG(logINFO) <<__FUNCTION__<<": ["<<getId()<<"]["<<prm.statusCode<<"]";
+
+	if (prm.statusCode == 200) {
+		LOG(logINFO) <<__FUNCTION__<<": ["<<getId()<<"] transfer was successfully handled. Hanging up";
+		CallOpParam prm(true);
+		hangup(prm);
+	}
+}
+
+void TestCall::onCallMediaState(OnCallMediaStateParam &prm) {
+	PJ_UNUSED_ARG(prm);
+	CallInfo ci = getInfo();
+
+	LOG(logINFO) <<__FUNCTION__<<": ["<<getId()<<"]["<<ci.remoteUri<<"]["<<ci.stateText<<"]id["<<ci.callIdString<<"]";
+	LOG(logINFO) <<__FUNCTION__<<": ["<<getId()<<"] call is on hold";
 }
 
 
@@ -1156,5 +1174,3 @@ int main(int argc, char **argv){
 	LOG(logINFO) <<__FUNCTION__<<": Watch completed, exiting  /('l')" ;
 	return ret;
 }
-
-

--- a/src/voip_patrol/voip_patrol.hh
+++ b/src/voip_patrol/voip_patrol.hh
@@ -241,6 +241,7 @@ class TestCall : public Call {
 		virtual void onCallTsxState(OnCallTsxStateParam &prm);
 		virtual void onCallState(OnCallStateParam &prm);
 		virtual void onCallTransferStatus(OnCallTransferStatusParam &prm);
+		virtual void onCallMediaState(OnCallMediaStateParam &prm);
 		virtual void onStreamCreated(OnStreamCreatedParam &prm);
 		virtual void onStreamDestroyed(OnStreamDestroyedParam &prm);
 		virtual void onDtmfDigit(OnDtmfDigitParam &prm);

--- a/src/voip_patrol/voip_patrol.hh
+++ b/src/voip_patrol/voip_patrol.hh
@@ -240,6 +240,7 @@ class TestCall : public Call {
 		virtual void onCallRxOffer(OnCallTsxStateParam &prm);
 		virtual void onCallTsxState(OnCallTsxStateParam &prm);
 		virtual void onCallState(OnCallStateParam &prm);
+		virtual void onCallTransferStatus(OnCallTransferStatusParam &prm);
 		virtual void onStreamCreated(OnStreamCreatedParam &prm);
 		virtual void onStreamDestroyed(OnStreamDestroyedParam &prm);
 		virtual void onDtmfDigit(OnDtmfDigitParam &prm);

--- a/xml/transfer.xml
+++ b/xml/transfer.xml
@@ -1,0 +1,24 @@
+<config>
+	<actions>
+		<action type="register" label="CALLEE REGISTRATION"
+			transport="udp"
+			account="VP_ENV_CALLEE_USERNAME"
+			username="VP_ENV_CALLEE_USERNAME"
+			password="VP_ENV_CALLEE_PASSWORD"
+			proxy="VPN_ENV_PROXY"
+			realm="VPN_ENV_DOMAIN"
+			registrar="VPN_ENV_DOMAIN"
+			expected_cause_code="200"
+		/>
+		<action type="wait" complete/>
+		<action type="accept" label="CALLEE recieves call and blind transfer"
+			account="VP_ENV_CALLEE_USERNAME"
+			wait_until="DISCONNECTED"
+			play="../voice_ref_files/reference_8000.wav"
+			code="200" reason="OK"
+			ring_duration="5"
+			rtp_stats
+		/>
+	<action type="transfer" blind to_uri="VPN_ENV_TRANSFER_TARGET@VPN_ENV_PROXY"/>
+	</action>
+</config>

--- a/xml/transfer.xml
+++ b/xml/transfer.xml
@@ -11,7 +11,7 @@
 			expected_cause_code="200"
 		/>
 		<action type="wait" complete/>
-		<action type="accept" label="CALLEE recieves call and blind transfer"
+		<action type="accept" label="CALLEE recieves call and transfers"
 			account="VP_ENV_CALLEE_USERNAME"
 			wait_until="DISCONNECTED"
 			play="../voice_ref_files/reference_8000.wav"
@@ -19,6 +19,6 @@
 			ring_duration="5"
 			rtp_stats
 		/>
-	<action type="transfer" blind to_uri="VPN_ENV_TRANSFER_TARGET@VPN_ENV_PROXY"/>
+	<action type="transfer" to_uri="VPN_ENV_TRANSFER_TARGET@VPN_ENV_PROXY"/>
 	</action>
 </config>


### PR DESCRIPTION
This change implements a "transfer" action option. It only implements a "blind" transfer in the sense that it just sends the REFER and hangs up once it get the final NOTIFY with 200 OK. I think in theory you could construct an "attended" transfer scenario by adding a "hold" action, and setting up another call to be the transfer target. This is my first try at C++ and I reused a lot of the code that was already there, so please let me know if something is off or needs improvement.

I also added examples to the README on how to set up the new action.