### PR TITLE
outgoing SIP call TLS from internet to kamailio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+Makefile
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+voip_patrol
+tls/*
+xml/makecall*
+test_makecall*
+results.json*
+

--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -278,10 +278,10 @@ void Action::do_register(vector<ActionParam> &params, vector<ActionCheck> &check
 			LOG(logERROR) <<__FUNCTION__<<" TLS transport not supported";
 			return;
 		}
-		acc_cfg.idUri = "sips:" + account_name;
-		acc_cfg.regConfig.registrarUri = "sips:" + registrar;
+		acc_cfg.idUri = "sip:" + account_name;
+		acc_cfg.regConfig.registrarUri = "sip:" + registrar + ";transport=tls" ;
 		if (!proxy.empty())
-			acc_cfg.sipConfig.proxies.push_back("sips:" + proxy);
+			acc_cfg.sipConfig.proxies.push_back("sip:" + proxy);
 		LOG(logINFO) <<__FUNCTION__<< " SIPS/TLS URI Scheme";
 	} else {
 		LOG(logINFO) <<__FUNCTION__<< " SIP UDP";
@@ -516,9 +516,9 @@ void Action::do_call(vector<ActionParam> &params, vector<ActionCheck> &checks, S
 				LOG(logERROR) <<__FUNCTION__<<": TLS transport not supported" ;
 				return;
 			}
-			acc_cfg.idUri = "sips:" + account_uri;
+			acc_cfg.idUri = "sip:" + account_uri;
 			if (!proxy.empty())
-				acc_cfg.sipConfig.proxies.push_back("sips:" + proxy);
+				acc_cfg.sipConfig.proxies.push_back("sip:" + proxy);
 		} else {
 			acc_cfg.idUri = "sip:" + account_uri;
 			if (!proxy.empty())
@@ -588,9 +588,9 @@ void Action::do_call(vector<ActionParam> &params, vector<ActionCheck> &checks, S
 		LOG(logINFO) << "calling :" +callee;
 		if (transport == "tls") {
 			if (!to_uri.empty())
-					to_uri = "sips:"+to_uri;
+					to_uri = "sip:"+to_uri;
 			try {
-				call->makeCall("sips:"+callee, prm, to_uri);
+				call->makeCall("sip:"+callee + ";transport=tls", prm, to_uri);
 			} catch (pj::Error e)  {
 				LOG(logERROR) <<__FUNCTION__<<" error :" << e.status << std::endl;
 			}

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -880,8 +880,6 @@ TestAccount* Config::createAccount(AccountConfig acc_cfg) {
 	acc_cfg.mediaConfig.transportConfig.publicAddress = ip_cfg.public_address;
 	if (ip_cfg.public_address != "")
 		acc_cfg.natConfig.sipStunUse = PJSUA_STUN_USE_DISABLED;
-	LOG(logINFO) <<__FUNCTION__<< "acc_cfg.natConfig.contactRewriteUse set to zero";
-	acc_cfg.natConfig.contactRewriteUse=0;		
 	account->create(acc_cfg);
 	AccountInfo acc_inf = account->getInfo();
 	LOG(logINFO) <<__FUNCTION__<< ": ["<< acc_inf.id << "]["<<acc_inf.uri<<"]";

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -880,6 +880,8 @@ TestAccount* Config::createAccount(AccountConfig acc_cfg) {
 	acc_cfg.mediaConfig.transportConfig.publicAddress = ip_cfg.public_address;
 	if (ip_cfg.public_address != "")
 		acc_cfg.natConfig.sipStunUse = PJSUA_STUN_USE_DISABLED;
+	LOG(logINFO) <<__FUNCTION__<< "acc_cfg.natConfig.contactRewriteUse set to zero";
+	acc_cfg.natConfig.contactRewriteUse=0;		
 	account->create(acc_cfg);
 	AccountInfo acc_inf = account->getInfo();
 	LOG(logINFO) <<__FUNCTION__<< ": ["<< acc_inf.id << "]["<<acc_inf.uri<<"]";


### PR DESCRIPTION
Outgoing tls call fix  : tls transport added in REGISTER and INVITE, "sips:" scheme replaced by "sip:"