### PR TITLE
tls transport with "sip:" scheme instead of "sips:"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+Makefile
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+voip_patrol
+tls/*
+xml/makecall*
+test_makecall*
+results.json*
+

--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -278,10 +278,10 @@ void Action::do_register(vector<ActionParam> &params, vector<ActionCheck> &check
 			LOG(logERROR) <<__FUNCTION__<<" TLS transport not supported";
 			return;
 		}
-		acc_cfg.idUri = "sips:" + account_name;
-		acc_cfg.regConfig.registrarUri = "sips:" + registrar;
+		acc_cfg.idUri = "sip:" + account_name;
+		acc_cfg.regConfig.registrarUri = "sip:" + registrar + ";transport=tls" ;
 		if (!proxy.empty())
-			acc_cfg.sipConfig.proxies.push_back("sips:" + proxy);
+			acc_cfg.sipConfig.proxies.push_back("sip:" + proxy);
 		LOG(logINFO) <<__FUNCTION__<< " SIPS/TLS URI Scheme";
 	} else {
 		LOG(logINFO) <<__FUNCTION__<< " SIP UDP";
@@ -516,9 +516,9 @@ void Action::do_call(vector<ActionParam> &params, vector<ActionCheck> &checks, S
 				LOG(logERROR) <<__FUNCTION__<<": TLS transport not supported" ;
 				return;
 			}
-			acc_cfg.idUri = "sips:" + account_uri;
+			acc_cfg.idUri = "sip:" + account_uri;
 			if (!proxy.empty())
-				acc_cfg.sipConfig.proxies.push_back("sips:" + proxy);
+				acc_cfg.sipConfig.proxies.push_back("sip:" + proxy);
 		} else {
 			acc_cfg.idUri = "sip:" + account_uri;
 			if (!proxy.empty())
@@ -588,9 +588,9 @@ void Action::do_call(vector<ActionParam> &params, vector<ActionCheck> &checks, S
 		LOG(logINFO) << "calling :" +callee;
 		if (transport == "tls") {
 			if (!to_uri.empty())
-					to_uri = "sips:"+to_uri;
+					to_uri = "sip:"+to_uri;
 			try {
-				call->makeCall("sips:"+callee, prm, to_uri);
+				call->makeCall("sip:"+callee + ";transport=tls", prm, to_uri);
 			} catch (pj::Error e)  {
 				LOG(logERROR) <<__FUNCTION__<<" error :" << e.status << std::endl;
 			}

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -1283,7 +1283,7 @@ int main(int argc, char **argv){
 		ep_cfg.logConfig.filename = pj_log_fn.c_str();
 		ep_cfg.medConfig.ecTailLen = 0; // disable echo canceller
 		ep_cfg.medConfig.noVad = 1;
-		// ep_cfg.uaConfig.nameserver.push_back("8.8.8.8");
+		ep_cfg.uaConfig.nameserver.push_back("8.8.8.8");
 
 		ep.libInit(ep_cfg);
 		// pjsua_set_null_snd_dev() before calling pjsua_start().


### PR DESCRIPTION
tested on TLS **outgoing** calls only. Voip Patrol playing the role of client and Kamailio the role of SIP TLS server.