### PR TITLE
rework of `check-message` and `check-header`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ It is possible to test many scenarios that are not easy to test manually like a 
 </config>
 ```
 
+### Example: accepting calls and checking for specific header with exact match or regular expression and no match on other
+```xml
+<config>
+  <actions>
+    <action type="accept"
+            match_account="default"
+            hangup="5"
+            code="200" reason="OK"
+    >
+        <check-header name="Min-SE"/>
+        <!-- Chech that a header exists -->
+        <check-header name="X-Foo" value="Bar"/>
+        <!-- Chech that a header exists and have a specific value -->
+        <check-header name="From" regex="^.*sip:\+1234@example\.com"/>
+        <!-- Chech that a header exists and matches a specific regex -->
+        <check-header name="To" regex="^.*sip:\+5678@example\.com" fail_on_match="true"/>
+        <!-- Chech that a header exists and NOT matches a specific regex -->
+    </action>
+    <action type="wait" ms="-1"/>
+  </actions>
+</config>
+```
+
 ### Example: accepting calls and searching the message with a regular expression
 ```xml
 <config>

--- a/src/voip_patrol/check.cc
+++ b/src/voip_patrol/check.cc
@@ -19,56 +19,105 @@
 #include "pj_util.hpp"
 #include <regex>
 
-
-
 bool check_regex(string m, string e) {
 	std::istringstream ss(m);
 	std::string line;
 	std::regex re(e);
+
 	while (std::getline(ss, line)) {
 		line.pop_back();
-		LOG(logINFO) <<__FUNCTION__<<">>> "<< line;
+
+		LOG(logINFO) << __FUNCTION__ << " >>> " << line;
+
 		if (std::regex_match(line, re)) {
-			LOG(logINFO) <<__FUNCTION__<<": matching ! ["<<e<<"]";
+			LOG(logINFO) << __FUNCTION__ << ": matching ! [" << e << "]";
+
 			return true;
 		}
 	}
-	LOG(logINFO) <<__FUNCTION__<<": not matching ! ["<<e<<"]";
+	LOG(logINFO) << __FUNCTION__ << ": not matching ! [" << e << "]";
+
 	return false;
 }
 
 
 void check_checks(vector<ActionCheck> &checks, pjsip_msg* msg, string message) {
 	std::string method = pj2Str(msg->line.req.method.name);
-	LOG(logINFO) <<__FUNCTION__<<": "+ method;
-	// action checks for headers
-	for (vector<ActionCheck> :: iterator check = checks.begin(); check != checks.end(); ++check){
-		if (!check->regex.empty()) {
-			if (method != check->method) continue;
-			if (check_regex(message, check->regex)) {
-				check->result = true;
+
+	LOG(logINFO) << __FUNCTION__ << ": " + method;
+
+	for (vector<ActionCheck> :: iterator check = checks.begin(); check != checks.end(); ++check) {
+		// Message checks
+		if (check->type == "message") {
+			if (!check->regex.empty()) {
+				if (method != check->method) {
+					continue;
+				}
+				if (check_regex(message, check->regex)) {
+					check->result = true;
+				}
+				if (check->fail_on_match) {
+					check->result = not check->result;
+
+					LOG(logINFO) << __FUNCTION__ << ": fail_on_match is true, inverting result to " << check->result;
+				}
 			}
 			continue;
 		}
-		if (method != check->method) continue;
-		if (check->hdr.hName == "") continue;
-		LOG(logINFO) <<__FUNCTION__<<" check-header:"<< check->hdr.hName<<" "<<check->hdr.hValue;
-		pj_str_t header_name;
-		header_name.slen = strlen(check->hdr.hName.c_str());
-		header_name.ptr = (char*) check->hdr.hName.c_str();
 
-		pjsip_hdr* s_hdr = (pjsip_hdr*) pjsip_msg_find_hdr_by_name(msg, (const pj_str_t *) &header_name, NULL);
-		if (s_hdr) {
-			SipHeader SHdr;
-			SHdr.fromPj(s_hdr);
-			if (check->hdr.hValue == "" || check->hdr.hValue == SHdr.hValue) {
-				LOG(logINFO) <<__FUNCTION__<< " header found and value is matching:" << SHdr.hName <<" "<< SHdr.hValue;
-				check->result = true;
-			} else {
-				LOG(logINFO) <<__FUNCTION__<< " header found and value is not matching:" << SHdr.hName <<" "<< SHdr.hValue;
+		// Header checks
+		if (check->type == "header") {
+			if (method != check->method) {
+				continue;
 			}
-		} else {
-			LOG(logINFO) <<__FUNCTION__<< " header not found";
+
+			if (check->hdr.hName == "") {
+				continue;
+			}
+
+			LOG(logINFO) << __FUNCTION__ << " check-header:" << check->hdr.hName << " " << check->hdr.hValue;
+
+			pj_str_t header_name;
+			header_name.slen = strlen(check->hdr.hName.c_str());
+			header_name.ptr = (char*) check->hdr.hName.c_str();
+
+			pjsip_hdr* s_hdr = (pjsip_hdr*) pjsip_msg_find_hdr_by_name(msg, (const pj_str_t *) &header_name, NULL);
+			if (s_hdr) {
+				SipHeader SHdr;
+				SHdr.fromPj(s_hdr);
+
+				if (check->hdr.hValue == "" || check->hdr.hValue == SHdr.hValue) {
+					LOG(logINFO) << __FUNCTION__ << " header found and value is matching:" << SHdr.hName << " " << SHdr.hValue;
+
+					check->result = true;
+				} else {
+					// Check if we have regex in pattern
+					if (check->hdr.hValue.length() >= 6 && check->hdr.hValue.substr(0,6) == "regex/") {
+						std::string header_value_regex = check->hdr.hValue.substr(6);
+
+						if (check_regex(SHdr.hValue, header_value_regex)) {
+							LOG(logINFO) << __FUNCTION__ << " header found and value is matching in regex style: " << SHdr.hName << " " << SHdr.hValue << " =~ " << header_value_regex;
+
+							check->result = true;
+						}
+					} else {
+						LOG(logINFO) << __FUNCTION__ << " header found and value is not matching: " << SHdr.hName << " " << SHdr.hValue << " != " << check->hdr.hValue;
+					}
+				}
+
+				if (check->fail_on_match) {
+					check->result = not check->result;
+
+					LOG(logINFO) << __FUNCTION__ << ": fail_on_match is true, inverting result to " << check->result;
+				}
+
+				continue;
+			}
+			// If header not found, we consider it as a fail anyways
+			LOG(logINFO) << __FUNCTION__ << " header not found";
+			continue;
 		}
+
+		LOG(logWARNING) << __FUNCTION__ << ": unknown check type: " << check->type;
 	}
 }

--- a/src/voip_patrol/check.hh
+++ b/src/voip_patrol/check.hh
@@ -29,7 +29,9 @@ class ActionCheck {
 		pj::SipHeader hdr;
 		string regex;
 		string method{"INVITE"};
+		string type {};
 		int code{0};
+		bool fail_on_match {false};
 		bool result{false};
 };
 

--- a/src/voip_patrol/voip_patrol.cc
+++ b/src/voip_patrol/voip_patrol.cc
@@ -58,6 +58,27 @@ string get_call_state_from_id (int state) {
 	return "UKNOWN";
 }
 
+// String to bool
+bool stob(std::string s) {
+    auto result = false;    // failure to assert is false
+
+    std::istringstream is(s);
+    // first try simple integer conversion
+    is >> result;
+
+    if (is.fail()) {
+        // simple integer failed; try boolean
+        is.clear();
+        is >> std::boolalpha >> result;
+    }
+
+    if (is.fail()) {
+        return false;
+    }
+
+    return result;
+}
+
 static pj_status_t stream_to_call(TestCall* call, pjsua_call_id call_id, const char *caller_contact ) {
 	pj_status_t status = PJ_SUCCESS;
 	// Create a player if none.
@@ -1108,38 +1129,60 @@ replay:
 			// <check-message>
 			for (xml_check = ezxml_child(xml_action, "check-message"); xml_check; xml_check=xml_check->next) {
 				ActionCheck check;
-				const char * val;
-				val = ezxml_attr(xml_check, "method");
-				if (val) {
-					check.method = string(val);
+				check.type = "message";
+				const char * val_inner = ezxml_attr(xml_check, "method");
+				if (val_inner) {
+					check.method = string(val_inner);
 				} else {
 					LOG(logERROR) <<__FUNCTION__<<"<check-message> missing [method] param !";
 					continue;
 				}
-				val = ezxml_attr(xml_check, "regex");
-				if (val) {
-					check.regex = string(val);
+				val_inner = ezxml_attr(xml_check, "regex");
+				if (val_inner) {
+					check.regex = string(val_inner);
 				} else {
 					LOG(logERROR) <<__FUNCTION__<<"<check-message> missing [regex] param !";
 					continue;
 				}
-				val = ezxml_attr(xml_check, "code");
-				if (val) check.code = atoi(val);
-				LOG(logINFO) <<__FUNCTION__<<" check-message: method["<<check.method<<"] regex["<< check.regex<<"]";
+				val_inner = ezxml_attr(xml_check, "code");
+				if (val_inner) {
+					check.code = atoi(val_inner);
+				}
+				val_inner = ezxml_attr(xml_check, "fail_on_match");
+				if (val_inner) {
+					check.fail_on_match = stob(val_inner);
+				}
+				LOG(logINFO) << __FUNCTION__ << " check-message: method[" << check.method << "] regex[" << check.regex<<"] fail_on_match[" << check.fail_on_match << "]";
+
 				checks.push_back(check);
 			}
 			// <checks-header>
 			for (xml_check = ezxml_child(xml_action, "check-header"); xml_check; xml_check=xml_check->next) {
 				ActionCheck check;
-				const char * val = ezxml_attr(xml_check, "name");
-				if (!val) {
+				check.type = "header";
+				const char * val_inner = ezxml_attr(xml_check, "name");
+				if (!val_inner) {
 					LOG(logERROR) <<__FUNCTION__<<" missing action check header name !";
 					continue;
 				}
-				check.hdr.hName = val;
-				val = ezxml_attr(xml_check, "value");
-				if (val) check.hdr.hValue = val;
-				LOG(logINFO) <<__FUNCTION__<<" check-header:"<< check.hdr.hName<<" "<<check.hdr.hValue;
+				check.hdr.hName = val_inner;
+				val_inner = ezxml_attr(xml_check, "value");
+				if (val_inner) {
+					check.hdr.hValue = val_inner;
+				} else {
+					val_inner = ezxml_attr(xml_check, "regex");
+					if (val_inner) {
+						std::string tmp_val;
+						tmp_val.assign(val_inner);
+						check.hdr.hValue = "regex/" + tmp_val;
+					}
+				}
+				val_inner = ezxml_attr(xml_check, "fail_on_match");
+				if (val_inner) {
+					check.fail_on_match = stob(val_inner);
+				}
+				LOG(logINFO) <<__FUNCTION__<< " check-header:" << check.hdr.hName << " " << check.hdr.hValue << " fail_on_match: " << check.fail_on_match;
+
 				checks.push_back(check);
 			}
 			string action_type = ezxml_attr(xml_action,"type");;


### PR DESCRIPTION
A bit redesigned check-header and check-message. Added a possibility to use regex'es in `check-header` and added an option `fail_on_match`, that allows to specify what you don't want to have in a message. Negative lookahead in regex here not helps, as it will return true after first non-match.
A bit dirty code, but do the job